### PR TITLE
[PLT-563] [GKE] Problemas con Autoescalado

### DIFF
--- a/cloud/scope/managedmachinepool.go
+++ b/cloud/scope/managedmachinepool.go
@@ -200,9 +200,6 @@ func ConvertToSdkNodePool(nodePool infrav1exp.GCPManagedMachinePool, machinePool
 	if nodePool.Spec.MachineType != nil {
 		sdkNodePool.Config.MachineType = *nodePool.Spec.MachineType
 	}
-	if nodePool.Spec.MachineType != nil {
-		sdkNodePool.Config.MachineType = *nodePool.Spec.MachineType
-	}
 	if nodePool.Spec.DiskSizeGb != nil {
 		sdkNodePool.Config.DiskSizeGb = *nodePool.Spec.DiskSizeGb
 	}

--- a/cloud/scope/managedmachinepool.go
+++ b/cloud/scope/managedmachinepool.go
@@ -37,6 +37,8 @@ import (
 	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	// import apierrors
 )
 
 // ManagedMachinePoolScopeParams defines the input parameters used to create a new Scope.
@@ -198,6 +200,9 @@ func ConvertToSdkNodePool(nodePool infrav1exp.GCPManagedMachinePool, machinePool
 	if nodePool.Spec.MachineType != nil {
 		sdkNodePool.Config.MachineType = *nodePool.Spec.MachineType
 	}
+	if nodePool.Spec.MachineType != nil {
+		sdkNodePool.Config.MachineType = *nodePool.Spec.MachineType
+	}
 	if nodePool.Spec.DiskSizeGb != nil {
 		sdkNodePool.Config.DiskSizeGb = *nodePool.Spec.DiskSizeGb
 	}
@@ -284,9 +289,45 @@ func ConvertToSdkNodePools(nodePools []infrav1exp.GCPManagedMachinePool, machine
 	return res
 }
 
-// SetReplicas sets the replicas count in status.
+// SetReplicas sets the replicas count in status and spec.
 func (s *ManagedMachinePoolScope) SetReplicas(replicas int32) {
+	// Update the status replicas
 	s.GCPManagedMachinePool.Status.Replicas = replicas
+	log.Log.Info("Updated GCPManagedMachinePool.Status.Replicas", "Replicas", s.GCPManagedMachinePool.Status.Replicas)
+
+	// Update MachinePool.Spec.Replicas to reflect the changes
+	if err := s.updateMachinePoolReplicas(context.TODO(), replicas); err != nil {
+		log.Log.Error(err, "Failed to update MachinePool.Spec.Replicas")
+	}
+
+}
+
+// updateMachinePoolReplicas updates the MachinePool replicas based on setReplicas.
+func (s *ManagedMachinePoolScope) updateMachinePoolReplicas(ctx context.Context, replicas int32) error {
+	log := log.FromContext(ctx)
+	// Fetch the corresponding MachinePool
+	machinePool := &clusterv1exp.MachinePool{}
+	if err := s.client.Get(ctx, client.ObjectKey{
+		Namespace: s.GCPManagedMachinePool.Namespace,
+		Name:      s.GCPManagedMachinePool.Name,
+	}, machinePool); err != nil {
+		log.Error(err, "Failed to fetch MachinePool")
+		return err
+	}
+
+	// Update MachinePool.Spec.Replicas to match GCPManagedMachinePool.Status.Replicas
+	if replicas != 0 {
+		machinePool.Spec.Replicas = &replicas
+		log.Info("Updated MachinePool.Spec.Replicas", "Replicas", replicas)
+
+		// Persist the changes
+		if err := s.client.Update(ctx, machinePool); err != nil {
+			log.Error(err, "Failed to update MachinePool Spec.Replicas")
+			return err
+		}
+	}
+
+	return nil
 }
 
 // NodePoolName returns the node pool name.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedcontrolplanes.yaml
@@ -127,9 +127,9 @@ spec:
                     type: boolean
                 type: object
               networkPolicy:
-                description: NetworkPolicy represents configuration options for NetworkPolicy
-                  feature of the GKE cluster. This feature is disabled if this field
-                  is not specified.
+                description: |-
+                  NetworkPolicy represents configuration options for NetworkPolicy feature of the GKE cluster.
+                  This feature is disabled if this field is not specified.
                 properties:
                   provider:
                     description: The selected network policy provider.


### PR DESCRIPTION
## Description

Al autoescalar un grupo de nodos, las instancias se crean y se agregan al cluster de K8s como nodos en Ready, pero no se refleja el cambio de replicas en el "spec.replicas" de lo "machinepools".

Solución propuesta:

Aprovechar la actualización de los gcpmanagedmachinepools en la reconciliación para poder reconciliar el spec.replicas en los machinepools.

## Related Pull Requests

- PR: https://github.com/Stratio/kind/pull/588

## Pull Request Checklist:

- [X] [PR title] Include a title referencing a ticket in Jira (e.g. "[PLT-99] Implement a new funcionality").
- [X] [PR desc] Add a summary of the changes made in simple terms.
- [X] [PR desc] List any pull-request related to this change (docs, tests, feature, etc.).
- [X] [PR labels] Add the corresponding labels (release, skips, cherry-pick, AT-eks-smoke, etc).
- [ ] [Docs] Are changes to the documentation required? (if so, please add references to those PRs).
- [ ] [QA] Are new unit tests required according with the changes? (if so, please add references to those PRs).

## Tests Done:
- Autoescalado a partir de un Deployment (Escalado/Des-escalado)
- Modificaciones en el cluster-operator (Creación de nuevos nodos, modificación, borrado)
- Lanzamiento del autoescalado y escalad/desescalado de nodos del keoscluster al mismo tiempo)

[PLT-99]: https://stratio.atlassian.net/browse/PLT-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ