### PR TITLE
[PLT-326] [GKE] Adding taints to a node_group

### DIFF
--- a/cloud/services/container/nodepools/reconcile.go
+++ b/cloud/services/container/nodepools/reconcile.go
@@ -307,8 +307,14 @@ func (s *Service) createNodePool(ctx context.Context, log *logr.Logger) error {
 }
 
 func (s *Service) updateNodePoolConfig(ctx context.Context, updateNodePoolRequest *containerpb.UpdateNodePoolRequest) error {
+	log := log.FromContext(ctx)
 	_, err := s.scope.ManagedMachinePoolClient().UpdateNodePool(ctx, updateNodePoolRequest)
 	if err != nil {
+		if strings.Contains(err.Error(), "CLUSTER_ALREADY_HAS_OPERATION") {
+			// Handle specific error without logging noise
+			log.Info("Cluster is currently undergoing another operation", "error", "Cluster is running incompatible operation")
+			return nil
+		}
 		return err
 	}
 
@@ -370,7 +376,7 @@ func (s *Service) checkDiffAndPrepareUpdateConfig(existingNodePool *containerpb.
 		}
 	}
 	// Kubernetes taints
-	if !cmp.Equal(desiredNodePool.Config.GetTaints(), existingNodePool.Config.Taints) {
+	if !cmp.Equal(desiredNodePool.Config.GetTaints(), existingNodePool.Config.Taints, cmpopts.IgnoreUnexported(containerpb.NodeTaint{})) {
 		needUpdate = true
 		updateNodePoolRequest.Taints = &containerpb.NodeTaints{
 			Taints: desiredNodePool.Config.GetTaints(),


### PR DESCRIPTION
## Description

En un cluster de GKE, añadir taints a un grupo de nodos produce un error en el capg-controller-manager haciendo que el pod crashee constantemente.
Esto ocurre tanto si desplegamos con taints en un grupo de nodos como si los añadimos a posteriori a través de keoscluster.

Solución propuesta:

Utilizar "cmpopts.IgnoreUnexported(containerpb.NodeTaint{})" para ignorar los campos no exportados en la estructura NodeTaint durante la comparación.

## Related Pull Requests

PR: None

## Pull Request Checklist:

- [X] [PR title] Include a title referencing a ticket in Jira (e.g. "[PLT-99] Implement a new funcionality").
- [X] [PR desc] Add a summary of the changes made in simple terms.
- [] [PR desc] List any pull-request related to this change (docs, tests, feature, etc.).
- [X] [PR labels] Add the corresponding labels (release, skips, cherry-pick, AT-eks-smoke, etc).
- [ ] [Docs] Are changes to the documentation required? (if so, please add references to those PRs).
- [ ] [QA] Are new unit tests required according with the changes? (if so, please add references to those PRs).

## Tests Done:
- Instalar con un grupo de nodos con taints
- Modificar/añadir Taints en ese grupo de nodos.


[PLT-99]: https://stratio.atlassian.net/browse/PLT-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ