### PR TITLE
[Fix] CVE-2024-34156 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.21.12 as builder
+FROM golang:1.22.7 as builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-gcp
 
-go 1.21
+go 1.22.7
 
 replace (
 	// pinning cel-go due to a breaking change https://github.com/kubernetes/apiserver/issues/97

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-gcp/hack/tools
 
-go 1.21.9
+go 1.22.7
 
 replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.7.0
 


### PR DESCRIPTION
HIGH Vulnerability found in non os package (go-module) - stdlib-go1.21.12 
(CVE-2024-34156 - https://nvd.nist.gov/vuln/detail/CVE-2024-34156)