### PR TITLE
[AUTO cherry-pick branch-1.6.1-0.2->main] [PLT-911] External

### DIFF
--- a/cloud/services/container/clusters/reconcile.go
+++ b/cloud/services/container/clusters/reconcile.go
@@ -269,6 +269,7 @@ func (s *Service) createCluster(ctx context.Context, log *logr.Logger) error {
 		cn := s.scope.GCPManagedControlPlane.Spec.ClusterNetwork
 		if cn.PrivateCluster != nil {
 			cluster.PrivateClusterConfig = &containerpb.PrivateClusterConfig{}
+			cluster.PrivateClusterConfig.EnablePrivateEndpoint = cn.PrivateCluster.EnablePrivateEndpoint
 			cluster.PrivateClusterConfig.EnablePrivateNodes = cn.PrivateCluster.EnablePrivateNodes
 			cluster.PrivateClusterConfig.MasterIpv4CidrBlock = cn.PrivateCluster.ControlPlaneCidrBlock
 		}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedcontrolplanes.yaml
@@ -79,6 +79,11 @@ spec:
                           ControlPlaneCidrBlock is the IP range in CIDR notation to use for the hosted master network. This range must not
                           overlap with any other ranges in use within the cluster's network. Honored when enabled is true.
                         type: string
+                      enablePrivateEndpoint:
+                        description: |-
+                          EnablePrivateEndpoint: Whether the master's internal IP
+                          address is used as the cluster endpoint.
+                        type: boolean
                       enablePrivateNodes:
                         description: |-
                           EnablePrivateNodes: Whether nodes have internal IP

--- a/exp/api/v1beta1/gcpmanagedcontrolplane_types.go
+++ b/exp/api/v1beta1/gcpmanagedcontrolplane_types.go
@@ -28,6 +28,10 @@ const (
 )
 
 type PrivateCluster struct {
+	// EnablePrivateEndpoint: Whether the master's internal IP
+	// address is used as the cluster endpoint.
+	// +optional
+	EnablePrivateEndpoint bool `json:"enablePrivateEndpoint,omitempty"`
 	// EnablePrivateNodes: Whether nodes have internal IP
 	// addresses only. If enabled, all nodes are given only RFC
 	// 1918 private addresses and communicate with the master via

--- a/manifests/infrastructure-components.yaml
+++ b/manifests/infrastructure-components.yaml
@@ -2162,6 +2162,11 @@ spec:
                           ControlPlaneCidrBlock is the IP range in CIDR notation to use for the hosted master network. This range must not
                           overlap with any other ranges in use within the cluster's network. Honored when enabled is true.
                         type: string
+                      enablePrivateEndpoint:
+                        description: |-
+                          EnablePrivateEndpoint: Whether the master's internal IP
+                          address is used as the cluster endpoint.
+                        type: boolean
                       enablePrivateNodes:
                         description: |-
                           EnablePrivateNodes: Whether nodes have internal IP
@@ -2801,9 +2806,9 @@ rules:
   verbs:
   - get
   - list
-  - watch
-  - update
   - patch
+  - update
+  - watch
 - apiGroups:
   - cluster.x-k8s.io
   resources:
@@ -3016,7 +3021,6 @@ spec:
         - --feature-gates=GKE=${EXP_CAPG_GKE:=false}
         - --diagnostics-address=${CAPG_DIAGNOSTICS_ADDRESS:=:8443}
         - --insecure-diagnostics=${CAPG_INSECURE_DIAGNOSTICS:=false}
-        - --sync-period=2m
         - --v=${CAPG_LOGLEVEL:=0}
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -3033,7 +3037,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/clusterapi-369611/cluster-api-gcp-controller-amd64:1.6.1-SNAPSHOT
+        image: gcr.io/k8s-staging-cluster-api-gcp/cluster-api-gcp-controller:e2e
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/manifests/metadata.yaml
+++ b/manifests/metadata.yaml
@@ -32,3 +32,6 @@ releaseSeries:
   - major: 1
     minor: 6
     contract: v1beta1
+  - major: 1
+    minor: 7
+    contract: v1beta1


### PR DESCRIPTION
AUTO cherry-picking [PLT-911] External Endpoint disabled (#20)

* Fix CVE-2024-34156

* Fix CVE-2024-34156

* [BUILD] New CI branch: branch-1.6.1-0.2

* Prepare for next version: 1.6.1-0.3.0-SNAPSHOT

* External endpoint disabled

* Fix CHANGELOG.md

* Fix VERSION file

* Fix CHANGELOG.md

---------

Co-authored-by: stratiocommit <stratiocommit@stratio.com>
Co-authored-by: Antonio López <33625777+alopez-stratio@users.noreply.github.com>

Remember to remove this branch once this PR is merged!

[PLT-911]: https://stratio.atlassian.net/browse/PLT-911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ